### PR TITLE
Upgrade Swift setup action in CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,9 @@ jobs:
     - name: Checkout code
       uses: actions/checkout@v7
     - name: Install Swift
-      uses: swift-actions/setup-swift@v2.4.0
+      uses: swift-actions/setup-swift@v3.0.0-beta.1
+      with:
+        skip-verify-signature: ${{ matrix.os == 'ubuntu-latest' }}
     - name: Run tests
       run: swift test --enable-code-coverage -Xswiftc -warnings-as-errors
     - name: Generate test coverage report


### PR DESCRIPTION
Updated Swift setup action to version 3.0.0-beta.1 and added skip-verify-signature option for Ubuntu.